### PR TITLE
Timing and audio fixes for USB

### DIFF
--- a/rtl_emard/lattice/ulx3s/top/amiga_ulx3s_usbjoy.vhd
+++ b/rtl_emard/lattice/ulx3s/top/amiga_ulx3s_usbjoy.vhd
@@ -339,10 +339,10 @@ begin
   generic map
   (
         in_Hz => natural( 25.0e6    ),
-      out0_Hz => natural(140.625e6  ),                  out0_tol_hz => 0,
-      out1_Hz => natural(112.5e6    ), out1_deg =>  90, out1_tol_hz => 0,
-      out2_Hz => natural( 28.125e6  ), out2_deg =>   0, out2_tol_hz => 0,
-      out3_Hz => natural(  7.03125e6), out3_deg =>   0, out3_tol_hz => 0
+      out0_Hz => natural(112.5e6    ),                  out0_tol_hz => 0,
+      out1_Hz => natural(112.5e6    ), out1_deg => 240, out1_tol_hz => 0,
+      out2_Hz => natural( 28.125e6  ), out2_deg => 240, out2_tol_hz => 0,
+      out3_Hz => natural(  7.03125e6), out3_deg => 240, out3_tol_hz => 0
   )
   port map
   (
@@ -350,29 +350,43 @@ begin
     clk_o   => clocks_a,
     locked  => pll_locked
   );
-  clk_dvi <= clocks_a(0);
-  --clk     <= clocks_a(1);
-  clk28m  <= clocks_a(2);
-  clk7m   <= clocks_a(3);
+  sdram_clk <= clocks_a(0);
+  clk       <= clocks_a(1);
+  clk28m    <= clocks_a(2);
+  clk7m     <= clocks_a(3);
 
   G_clk_usb_low: if C_usb_speed = '0' generate
   clk1 : entity work.ecp5pll
   generic map
   (
-        in_Hz => natural( 25.0e6),
-      out0_Hz => natural(112.5e6),                  out0_tol_hz => 0,
-      out1_Hz => natural(112.5e6), out1_deg =>  90, out1_tol_hz => 0,
-      out2_Hz => natural(  6.0e6), out2_deg =>   0, out2_tol_hz => 0,
-      out3_Hz => natural(  6.0e6), out3_deg =>   0, out3_tol_hz => 0
+        in_Hz => natural( 25.0e6  ),
+      out0_Hz => natural(140.625e6),                  out0_tol_hz => 0,
+      out1_Hz => natural(140.625e6), out1_deg => 240, out1_tol_hz => 0,
+      out2_Hz => natural(112.5e6  ), out2_deg =>   0, out2_tol_hz => 0,
+      out3_Hz => natural(112.5e6  ), out3_deg =>   0, out3_tol_hz => 0
   )
   port map
   (
     clk_i   => sys_clock,
     clk_o   => clocks_b
   );
-  clk       <= clocks_b(0);
-  sdram_clk <= clocks_b(1);
-  clk_usb   <= clocks_b(2);
+  clk_dvi   <= clocks_b(1);
+
+  clk2 : entity work.ecp5pll
+  generic map
+  (
+        in_Hz => natural( 25.0e6 ),
+      out0_Hz => natural( 240.0e6),                  out0_tol_hz => 0,
+      out1_Hz => natural( 48.0e6 ), out1_deg =>   0, out1_tol_hz => 0,
+      out2_Hz => natural(  6.0e6 ), out2_deg => 240, out2_tol_hz => 0,
+      out3_Hz => natural(  6.0e6 ), out3_deg =>   0, out3_tol_hz => 0
+  )
+  port map
+  (
+    clk_i   => sys_clock,
+    clk_o   => clocks_c
+  );
+  clk_usb   <= clocks_c(2);
   end generate;
 
   G_clk_usb_high: if C_usb_speed = '1' generate
@@ -412,7 +426,7 @@ begin
 		
   u10 : entity work.poweronreset
   port map( 
-    clk => clk,
+    clk => sys_clock,
     reset_button => reset_combo1,
     reset_out => reset_n
   );		
@@ -505,8 +519,8 @@ begin
   );
   audio_v(1 downto 0) <= (others => S_spdif_out);
   end generate;
-  audio_l(3 downto 0) <= leftdatasum(14 downto 11);
-  audio_r(3 downto 0) <= rightdatasum(14 downto 11);
+  audio_l(2) <= DAC_L;
+  audio_r(2) <= DAC_R;
 
   vga2dvi_converter: entity work.vga2dvid
   generic map


### PR DESCRIPTION
I've had much better success with timings by splitting out the system
clocks, dvi clock and usb clock into separate PLLs. Then, taking a queue
from the DE1 timings, I effectively made a negative phase for the SDRAM
clock and it appears to be much more stable.

Also switched the analogue audio channels to use the Minimig DAC instead
of the ULX3S 4-bit DAC. Sounds a lot better now.